### PR TITLE
Fixed typo in unsplash users statistic method

### DIFF
--- a/src/UnsplashUsers.php
+++ b/src/UnsplashUsers.php
@@ -77,7 +77,7 @@ class UnsplashUsers extends BaseClass
      *
      * @return mixed
      */
-    public function statics($username, array $params)
+    public function statistics($username, array $params)
     {
         return $this->call('users/'.$username.'/statistics', $params);
     }


### PR DESCRIPTION
I checked for any other typo, but I couldn't find any.